### PR TITLE
SingleSeriesContext: Add linking_id and linked_to fields

### DIFF
--- a/src/config/table_context.rs
+++ b/src/config/table_context.rs
@@ -120,7 +120,9 @@ struct SingleSeriesContext {
     #[allow(unused)]
     rename_id: Option<String>, // This only works, when the identifier is a name and not a regex. Maybe need, two different structs?
     /// A unique ID that can be used to link to other series
+    #[allow(unused)]
     linking_id: Option<String>,
+    #[allow(unused)]
     /// List of IDs that link to other tables, can be used to determine the relationship between these columns
     linked_to: Option<Vec<String>>,
 }


### PR DESCRIPTION
This allows us to determine the relationship between columns or rows in the transformation and collection phase.