### PR TITLE
Remove int identifier

### DIFF
--- a/src/config/table_context.rs
+++ b/src/config/table_context.rs
@@ -112,18 +112,6 @@ impl CellContext {
     }
 }
 
-/// An identifier for a series, which can be either a name or a numerical index.
-///
-/// This allows for selecting columns or rows by their header name (e.g., "PatientID")
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Hash)]
-#[serde(untagged)]
-pub(crate) enum Identifier {
-    #[allow(unused)]
-    Name(String),
-    #[allow(unused)]
-    Number(usize),
-}
-
 /// Represents the context for one or more series (columns or rows).
 ///
 /// This enum acts as a dispatcher. It can either define the context for a
@@ -188,7 +176,7 @@ impl SeriesContext {
 pub(crate) struct SingleSeriesContext {
     #[allow(unused)]
     /// The unique identifier for the series.
-    pub(crate) identifier: Identifier,
+    pub(crate) identifier: String,
     #[allow(unused)]
     #[serde(default)]
     /// The semantic context found in the header/index of the series.
@@ -200,16 +188,16 @@ pub(crate) struct SingleSeriesContext {
     #[allow(unused)]
     #[serde(default)]
     /// List of IDs that link to other tables, can be used to determine the relationship between these columns
-    pub linked_to: Vec<Identifier>,
+    pub linked_to: Vec<String>,
 }
 
 impl SingleSeriesContext {
     #[allow(unused)]
     pub(crate) fn new(
-        identifier: Identifier,
+        identifier: String,
         id_context: Context,
         cells: Option<CellContext>,
-        linked_to: Vec<Identifier>,
+        linked_to: Vec<String>,
     ) -> Self {
         SingleSeriesContext {
             identifier,

--- a/src/extract/data_source.rs
+++ b/src/extract/data_source.rs
@@ -55,7 +55,7 @@ impl Extractable for DataSource {
 mod tests {
     use super::*;
     use crate::config::table_context::{
-        CellContext, Context, Identifier, SeriesContext, SingleSeriesContext, TableContext,
+        CellContext, Context, SeriesContext, SingleSeriesContext, TableContext,
     };
     use rstest::{fixture, rstest};
     use std::fmt::Write;
@@ -136,14 +136,14 @@ mod tests {
         let table_context = TableContext::new(
             "test_table".to_string(),
             vec![SeriesContext::Single(SingleSeriesContext::new(
-                Identifier::Name("patient_id".to_string()),
+                "patient_id".to_string(),
                 Context::None,
                 Some(CellContext::new(
                     Context::SubjectId,
                     None,
                     Default::default(),
                 )),
-                vec![Identifier::Name("HP:0000054".to_string())],
+                vec!["HP:0000054".to_string()],
             ))],
             true,
         );


### PR DESCRIPTION
Tried to argue at the bottom of this PR, why we do not need it int identifyer.

https://github.com/P2GX/PhenoXtract/pull/60