### PR TITLE
ContextualizedDataFrame: Adding Default trait

### DIFF
--- a/src/config/table_context.rs
+++ b/src/config/table_context.rs
@@ -10,7 +10,7 @@ use validator::Validate;
 ///
 /// This struct defines how to interpret a table, including its name and the
 /// context for its series, which can be organized as columns or rows.
-#[derive(Debug, Validate, Deserialize, Serialize, Clone, PartialEq)]
+#[derive(Debug, Validate, Deserialize, Serialize, Clone, PartialEq, Default)]
 #[validate(schema(
     function = "validate_at_least_one_subject_id",
     skip_on_field_errors = false

--- a/src/extract/contextualized_data_frame.rs
+++ b/src/extract/contextualized_data_frame.rs
@@ -5,7 +5,7 @@ use polars::prelude::DataFrame;
 ///
 /// This allows for processing the data within the `DataFrame` according to the
 /// rules and semantic information defined in the context.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Default)]
 pub struct ContextualizedDataFrame {
     #[allow(unused)]
     context: TableContext,


### PR DESCRIPTION
This will allow us to take ownership of the Contextualized table when applying a strategy.

Ownership can be taken via: std::mem::take