### PR TITLE
test(transform): add tests for `query_hpo_identifiers` in PhenopacketBuilder

### DIFF
--- a/src/transform/phenopacket_builder.rs
+++ b/src/transform/phenopacket_builder.rs
@@ -691,42 +691,42 @@ mod tests {
     }
 
     #[rstest]
-   fn test_query_hpo_identifiers_with_valid_label() {
-       let builder = PhenopacketBuilder::new(HPO_DICT.clone());
+    fn test_query_hpo_identifiers_with_valid_label() {
+        let builder = PhenopacketBuilder::new(HPO_DICT.clone());
 
-       // Known HPO label from test_utils::HPO_DICT: "Seizure" <-> "HP:0001250"
-       let result = builder.query_hpo_identifiers("Seizure").unwrap();
+        // Known HPO label from test_utils::HPO_DICT: "Seizure" <-> "HP:0001250"
+        let result = builder.query_hpo_identifiers("Seizure").unwrap();
 
-       assert_eq!(result.label, "Seizure");
-       assert_eq!(result.id, "HP:0001250");
-   }
+        assert_eq!(result.label, "Seizure");
+        assert_eq!(result.id, "HP:0001250");
+    }
 
-   #[rstest]
-   fn test_query_hpo_identifiers_with_valid_id() {
-       let builder = PhenopacketBuilder::new(HPO_DICT.clone());
+    #[rstest]
+    fn test_query_hpo_identifiers_with_valid_id() {
+        let builder = PhenopacketBuilder::new(HPO_DICT.clone());
 
-       // Query using the ID instead of label
-       let result = builder.query_hpo_identifiers("HP:0001250").unwrap();
+        // Query using the ID instead of label
+        let result = builder.query_hpo_identifiers("HP:0001250").unwrap();
 
-       assert_eq!(result.label, "Seizure");
-       assert_eq!(result.id, "HP:0001250");
-   }
+        assert_eq!(result.label, "Seizure");
+        assert_eq!(result.id, "HP:0001250");
+    }
 
-   #[rstest]
-   fn test_query_hpo_identifiers_invalid_query() {
-       let builder = PhenopacketBuilder::new(HPO_DICT.clone());
+    #[rstest]
+    fn test_query_hpo_identifiers_invalid_query() {
+        let builder = PhenopacketBuilder::new(HPO_DICT.clone());
 
-       // Nonexistent label or ID should yield an error
-       let result = builder.query_hpo_identifiers("NonexistentTerm");
+        // Nonexistent label or ID should yield an error
+        let result = builder.query_hpo_identifiers("NonexistentTerm");
 
-       assert!(result.is_err());
+        assert!(result.is_err());
 
-       if let Err(TransformError::BuilderError(msg)) = result {
-           assert!(msg.contains("Could not find ontology class for NonexistentTerm"));
-       } else {
-           panic!("Expected BuilderError for invalid query");
-       }
-   }
+        if let Err(TransformError::BuilderError(msg)) = result {
+            assert!(msg.contains("Could not find ontology class for NonexistentTerm"));
+        } else {
+            panic!("Expected BuilderError for invalid query");
+        }
+    }
 
     #[rstest]
     fn test_parse_time_element_duration() {


### PR DESCRIPTION
Add unit tests for the`PhenopacketBuilder::query_hpo_identifiers` function to resolve identifiers and labels using the internal `HPOBiDict`. Use the [Seizure HPO term](https://hpo.jax.org/browse/term/HP:0001250) to check