### PR TITLE
better patient grouping in the collector

### DIFF
--- a/src/transform/collector.rs
+++ b/src/transform/collector.rs
@@ -59,9 +59,7 @@ impl Collector {
                     .unwrap()
                     .get(0)
                     .unwrap();
-
                 let patient_id = patient_id_av.str_value();
-
                 let phenopacket_id = format!("{}-{}", self.cohort_name.clone(), patient_id);
 
                 let patient_cdf =


### PR DESCRIPTION
(in theory) the grouping by patient process is now much more efficient and doesn't rely on converting the patient_id col to a string vector