### PR TITLE
MetaData: Adding ontology versions

### DIFF
--- a/src/config/phenoxtracter_config.rs
+++ b/src/config/phenoxtracter_config.rs
@@ -276,6 +276,9 @@ meta_data:
   created_by: Rouven Reuter
   submitted_by: Magnus Knut Hansen
   cohort_name: "Arkham Asylum 2025"
+  hpo_version: "latest"
+  mondo_version: "latest"
+  geno_version: "latest"
     "#;
 
         let file_path = temp_dir.path().join("config.yaml");
@@ -288,6 +291,7 @@ meta_data:
                 created_by: Some("Rouven Reuter".to_string()),
                 submitted_by: "Magnus Knut Hansen".to_string(),
                 cohort_name: "Arkham Asylum 2025".to_string(),
+                ..Default::default()
             },
             pipeline: Some(PipelineConfig::new(
                 vec!["alias_mapping".to_string(), "fill_null".to_string()],


### PR DESCRIPTION
Will let us fetch the correct versions from obolib and add the correct version to the metadata of the phenopacket.