### PR TITLE
Fix mapping strategy

### DIFF
--- a/phenoxtract/src/transform/strategies/mapping.rs
+++ b/phenoxtract/src/transform/strategies/mapping.rs
@@ -190,7 +190,6 @@ impl Strategy for MappingStrategy {
             "Applying Mapping strategy to data. Applying synonyms to columns with header_context {} and data_context {}.",
             self.header_context, self.data_context
         );
-
         let mut error_info: HashSet<MappingErrorInfo> = HashSet::new();
 
         for table in tables.iter_mut() {
@@ -281,8 +280,8 @@ mod tests {
 
     fn make_test_dataframe() -> ContextualizedDataFrame {
         let df = df![
-            "sex" => &[AnyValue::String("m"), AnyValue::String("f"), AnyValue::String("male"), AnyValue::String("female"), AnyValue::String("man"), AnyValue::String("woman"), AnyValue::String("intersex"), AnyValue::String("mole"), AnyValue::Null],
-            "sub_id" => &[AnyValue::String("1"), AnyValue::String("2"), AnyValue::String("3"), AnyValue::String("4"), AnyValue::String("5"), AnyValue::String("6"), AnyValue::String("7"), AnyValue::String("8"), AnyValue::String("9")],
+            "sex" => &[AnyValue::String("m"), AnyValue::String("f"), AnyValue::String("male"), AnyValue::String("female"), AnyValue::String("man"), AnyValue::String("woman"), AnyValue::String("intersex"), AnyValue::String("mole"), AnyValue::Null, AnyValue::String("OTHER_SEX")],
+            "sub_id" => &[AnyValue::String("1"), AnyValue::String("2"), AnyValue::String("3"), AnyValue::String("4"), AnyValue::String("5"), AnyValue::String("6"), AnyValue::String("7"), AnyValue::String("8"), AnyValue::String("9"), AnyValue::String("10")],
         ]
         .unwrap();
 
@@ -336,6 +335,7 @@ mod tests {
                 "FEMALE",
                 "MALE",
                 "FEMALE",
+                "OTHER_SEX",
                 "OTHER_SEX"
             ]
         );
@@ -425,6 +425,7 @@ mod tests {
                 "OTHER_SEX",
                 "mole",
                 "",
+                "OTHER_SEX"
             ]
         );
     }


### PR DESCRIPTION
When one of the columns already contained a valid value, the strategy would complain, that that value can not be mapped.

Encountered when I used alias mapping to map transgender to OTHER_SEX